### PR TITLE
feat: require signing tx on withdrawing orders

### DIFF
--- a/src/pages/Trade/components/TradeContent/index.tsx
+++ b/src/pages/Trade/components/TradeContent/index.tsx
@@ -2,7 +2,7 @@
 import React, { useCallback, useEffect } from 'react'
 import { useContainer } from 'unstated-next'
 import { Table, Button, Input, Spin } from 'antd'
-import PWCore, { Address, Amount, OutPoint, AddressType } from '@lay2/pw-core'
+import PWCore, { Address, OutPoint, AddressType } from '@lay2/pw-core'
 import { TraceTableList } from '../../../../utils/const'
 import { TradeTableBox, FilterTablePire } from './styled'
 import toExplorer from '../../../../assets/img/toExplorer.png'
@@ -60,12 +60,10 @@ export default () => {
       const builder = new CancelOrderBuilder(
         new Address(Wallet.ckbWallet.address, AddressType.ckb),
         new OutPoint(outpoint.tx_hash, outpoint.index),
-        new Amount('80'),
       )
 
       try {
-        const hash = await Wallet.pw?.sendTransaction(await builder.build())
-        console.log(hash)
+        await Wallet.pw?.sendTransaction(await builder.build())
       } catch (error) {
         //
       } finally {

--- a/src/pw/cancelOrderBuilder.ts
+++ b/src/pw/cancelOrderBuilder.ts
@@ -1,35 +1,62 @@
-import PWCore, { Builder, Transaction, Cell, Amount, RawTransaction, Address, OutPoint } from '@lay2/pw-core'
-import { CKB_NODE_URL, ORDER_BOOK_LOOK_DEP, SUDT_DEP } from '../utils/const'
+import PWCore, {
+  Builder,
+  Transaction,
+  Cell,
+  Script,
+  Amount,
+  RawTransaction,
+  Address,
+  OutPoint,
+  AmountUnit,
+} from '@lay2/pw-core'
+import { ORDER_BOOK_LOOK_DEP, SUDT_DEP, CKB_NODE_URL } from '../utils/const'
 
 export class CancelOrderBuilder extends Builder {
   address: Address
 
-  outPoint: OutPoint
+  orderOutPoint: OutPoint
 
-  inputCapacity: Amount
+  core = new PWCore(CKB_NODE_URL)
 
-  constructor(address: Address, outPoint: OutPoint, inputCapacity: Amount, feeRate?: number) {
-    super(feeRate)
+  constructor(address: Address, outPoint: OutPoint) {
+    super()
     this.address = address
-    this.outPoint = outPoint
-    this.inputCapacity = inputCapacity
+    this.orderOutPoint = outPoint
   }
 
-  async build(fee: Amount = Amount.ZERO): Promise<Transaction> {
-    const outputCapacity = this.inputCapacity.sub(fee)
-    const input = await Cell.loadFromBlockchain(new PWCore(CKB_NODE_URL).rpc, this.outPoint)
-    const lockArgs = this.address.toLockScript()
-    // eslint-disable-next-line no-debugger
-    const output = new Cell(outputCapacity, lockArgs)
+  async build(): Promise<Transaction> {
+    const cells = await this.collector.collect(this.address, { withData: false } as any)
 
-    const tx = new Transaction(new RawTransaction([input], [output]), [Builder.WITNESS_ARGS.Secp256k1])
+    if (!cells.length) {
+      throw new Error('Cannot find extra cells for validation')
+    }
+
+    const orderCell = await this.#getOrderCell()
+
+    const inputCells: Cell[] = [cells[0], orderCell]
+    const outputCells: Cell[] = [cells[0], orderCell.clone()]
+
+    const tx = new Transaction(new RawTransaction(inputCells, outputCells), [Builder.WITNESS_ARGS.Secp256k1])
+
     tx.raw.cellDeps.push(ORDER_BOOK_LOOK_DEP)
     tx.raw.cellDeps.push(SUDT_DEP)
-    tx.raw.outputsData = ['0x']
-    this.fee = Builder.calcFee(tx)
-    tx.raw.outputs[0].capacity = outputCapacity.sub(this.fee)
 
+    outputCells[1].lock = this.address.toLockScript()
+    this.fee = Builder.calcFee(tx)
+    outputCells[1].capacity = outputCells[1].capacity.sub(this.fee)
     return tx
+  }
+
+  send() {
+    return this.core.sendTransaction(this)
+  }
+
+  #getOrderCell = async () => {
+    const res = await this.core.rpc.get_transaction(this.orderOutPoint.txHash)
+    const cell = res.transaction.outputs[+this.orderOutPoint.index]
+    const lockScript = new Script(cell.lock.code_hash, cell.lock.args, cell.lock.hash_type)
+    const orderCell = new Cell(new Amount(cell.capacity, AmountUnit.shannon), lockScript, undefined, this.orderOutPoint)
+    return orderCell
   }
 }
 

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -97,3 +97,6 @@ export const HISTORY_PARAMS = {
 export const HISTORY_QUERY_KEY = {
   type: 'history-type',
 }
+
+// TODO: use enum
+export const REJECT_ERROR_CODE = 4001


### PR DESCRIPTION
This commit enables invoking the wallet to sign the transaction on canceling/claiming orders.

The tx to sign is a 2-in-2-out tx

- The first pair of input/output is just used for ownership validation required by the order lock located at the second position, and no data will be changed;
- The second pair of input/output is the order to unlock, it pays the fee of the tx.