### PR TITLE
fix: fix unexpected disappearance of pending of claimed tx

### DIFF
--- a/src/APIs/checkSubmittedTxs.ts
+++ b/src/APIs/checkSubmittedTxs.ts
@@ -7,7 +7,7 @@ export const checkSubmittedTxs = (hashes: Array<string>) => {
   return ckb.rpc
     .createBatchRequest(requests)
     .exec()
-    .then(resList => resList.map(res => res.txStatus.status === 'committed'))
+    .then(resList => resList.map(res => res?.txStatus?.status === 'committed'))
     .catch(() => {
       return new Array<boolean>(requests.length).fill(false)
     })

--- a/src/__test__/utils/fixtures.json
+++ b/src/__test__/utils/fixtures.json
@@ -26,6 +26,7 @@
         "receive": "500",
         "executed": "60%",
         "price": "5",
+        "isClaimable": false,
         "status": "aborted",
         "action": null
       }
@@ -56,6 +57,7 @@
         "pay": "20.06000000",
         "executed": "0.5%",
         "price": "5",
+        "isClaimable": false,
         "status": "aborted",
         "action": null
       }

--- a/src/pages/Trade/components/History/hooks.ts
+++ b/src/pages/Trade/components/History/hooks.ts
@@ -58,6 +58,10 @@ export const reducer: React.Reducer<HistoryState, HistoryAction> = (state, actio
 
 type Order = ReturnType<typeof parseOrderRecord>
 
+const isOrderAbortedOrClaimed = (order: Order) => {
+  return order.status === 'aborted' || (order.status === 'completed' && !order.isClaimable)
+}
+
 export const usePollOrderList = ({
   lockArgs,
   dispatch,
@@ -76,7 +80,7 @@ export const usePollOrderList = ({
           .then(res => {
             const parsed = res.data.reverse().map((item: RawOrder) => {
               const order = parseOrderRecord(item)
-              if (order.status !== 'opening') {
+              if (isOrderAbortedOrClaimed(order)) {
                 pendingOrders.remove(order.key)
               }
               return order

--- a/src/pages/Trade/components/History/index.tsx
+++ b/src/pages/Trade/components/History/index.tsx
@@ -83,7 +83,7 @@ const columns = [
     title: 'status',
     dataIndex: 'status',
     key: 'status',
-    width: 90,
+    width: 100,
     render: (status: OrderInList['status'], order: OrderInList) => {
       const [txHash, index] = order.key.split(':')
 

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -53,6 +53,7 @@ export const parseOrderRecord = ({
     price: `${priceInNum}`,
     status,
     action: getAction(claimable, status === 'opening'),
+    isClaimable: claimable,
     ...rest,
   }
 }


### PR DESCRIPTION
Before this commit, all pending txs with `status !== 'opening'` will be removed from the pending list, which covers pending claimed txs(who have `status === 'completed'`) accidentally.

By this commit, only txs with `status === 'aborted'`(canceled order) or `status === 'completed' && claimable === false`(claimed order) will be removed.