### PR TITLE
feat: add claimed status

### DIFF
--- a/src/pages/Trade/components/History/history.module.css
+++ b/src/pages/Trade/components/History/history.module.css
@@ -89,6 +89,7 @@
 }
 
 a.status[data-status='aborted'],
-a.status[data-status='completed'] {
+a.status[data-status='completed'],
+a.status[data-status='claimed'] {
   color: #888;
 }

--- a/src/pages/Trade/components/History/hooks.ts
+++ b/src/pages/Trade/components/History/hooks.ts
@@ -28,12 +28,7 @@ export type HistoryAction =
 export const reducer: React.Reducer<HistoryState, HistoryAction> = (state, action) => {
   switch (action.type) {
     case ActionType.UpdateOrderList: {
-      const completedIds = action.value.filter(o => o.status !== 'opening').map(o => o.key)
-      return {
-        ...state,
-        orderList: action.value,
-        pendingIdList: state.pendingIdList.filter(id => !completedIds.includes(id)),
-      }
+      return { ...state, orderList: action.value }
     }
     case ActionType.AddPendingId: {
       if (!state.pendingIdList.includes(action.value)) {
@@ -58,10 +53,6 @@ export const reducer: React.Reducer<HistoryState, HistoryAction> = (state, actio
 
 type Order = ReturnType<typeof parseOrderRecord>
 
-const isOrderAbortedOrClaimed = (order: Order) => {
-  return order.status === 'aborted' || (order.status === 'completed' && !order.isClaimable)
-}
-
 export const usePollOrderList = ({
   lockArgs,
   dispatch,
@@ -80,7 +71,7 @@ export const usePollOrderList = ({
           .then(res => {
             const parsed = res.data.reverse().map((item: RawOrder) => {
               const order = parseOrderRecord(item)
-              if (isOrderAbortedOrClaimed(order)) {
+              if (['aborted', 'claimed'].includes(order.status ?? '')) {
                 pendingOrders.remove(order.key)
               }
               return order

--- a/src/pages/Trade/components/History/index.tsx
+++ b/src/pages/Trade/components/History/index.tsx
@@ -112,14 +112,10 @@ const orderFilter = (type: string, order: OrderInList) => {
   switch (type) {
     case 'pending':
     case 'opening':
-    case 'aborted': {
-      return order.status === type
-    }
-    case 'completed': {
-      return order.status === 'completed' && order.isClaimable
-    }
+    case 'aborted':
+    case 'completed':
     case 'claimed': {
-      return order.status === 'completed' && !order.isClaimable
+      return order.status === type
     }
     default: {
       return true

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -3,7 +3,7 @@ import { PRICE_DECIMAL, SUDT_DECIMAL, CKB_DECIMAL, COMMISSION_FEE } from './cons
 
 export type RawOrder = Record<'is_bid' | 'claimable', boolean> &
   Record<'order_amount' | 'traded_amount' | 'turnover_rate' | 'paid_amount' | 'price', string> & {
-    status: 'opening' | 'completed' | 'aborted' | null
+    status: 'opening' | 'completed' | 'aborted' | 'claimed' | null
     last_order_cell_outpoint: Record<'tx_hash' | 'index', string>
   }
 


### PR DESCRIPTION
`claimed` status will be introduced in the query api server, and it is used instead of `status === 'completed' && !isClaimable`